### PR TITLE
DPI-2854 Package flipTime in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipTime";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''Functions to aggregate time series into strings, and convert
+    strings back into dates.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    plotly
+    lubridate
+    flipU
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipTime in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR