### PR TITLE
FS2-4005: Handle empty strings in AsDateTime without erroring

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipTime
 Type: Package
 Title: Tools for Manipulating Dates and Time Series
-Version: 2.10.1
+Version: 2.10.2
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Functions to aggregate time series into strings, and convert

--- a/R/asdate.R
+++ b/R/asdate.R
@@ -45,7 +45,8 @@ AsDate <- function(x, us.format = NULL, exact = FALSE, on.parse.failure = "error
 
     ## Remove NAs and reinstate them before returning
     x.names <- names(x)
-    na.ind <- is.na(x)
+    na.ind <- if (is.character(x)) is.na(x) | x == ''
+              else is.na(x)
     x <- x[!na.ind]
 
     parsed <- asDate(x, us.format, exact)

--- a/R/asdatetime.R
+++ b/R/asdatetime.R
@@ -60,7 +60,8 @@ AsDateTime <- function(x, us.format = NULL, time.zone = "UTC", exact = FALSE,
 
     ## Remove NAs and reinstate them before returning
     x.names <- names(x)
-    na.ind <- is.na(x)
+    na.ind <- if (is.character(x)) is.na(x) | x == ''
+              else is.na(x)
     x <- x[!na.ind]
 
     parsed <- asDateTime(x, us.format, time.zone, exact)

--- a/tests/testthat/test-asdate.R
+++ b/tests/testthat/test-asdate.R
@@ -231,15 +231,15 @@ test_that("Dates with time stamps are parsed, with times dropped; DS-2193",
 
 test_that("DS-2798: deal with NAs",
 {
-    expect_equal(AsDate(c("2015","2015", NA, "2013", "2016"),
+    expect_equal(AsDate(c("2015","2015", NA, "2013", "2016", ""),
                         on.parse.failure = "ignore"),
-                 structure(c(16436, 16436, NA, 15706, 16801), class = "Date"))
+                 structure(c(16436, 16436, NA, 15706, 16801, NA), class = "Date"))
 })
 
 test_that("DS-2940: Keep names",
 {
-    expect_equal(AsDate(c(A = "2020-01-13", B = "2020-01-14", D = NA), on.parse.failure = "ignore"),
-        structure(c(A = 18274, B = 18275, D = NA), class = "Date"))
+    expect_equal(AsDate(c(A = "2020-01-13", B = "2020-01-14", D = NA, E = ""), on.parse.failure = "ignore"),
+        structure(c(A = 18274, B = 18275, D = NA, E = NA), class = "Date"))
 })
 
 test_that("RS-11414: '%' sign in names",

--- a/tests/testthat/test-asdatetime.R
+++ b/tests/testthat/test-asdatetime.R
@@ -192,9 +192,9 @@ test_that("IP addresses fail to parse; DS-2189",
 
 test_that("DS-2798: deal with NAs",
 {
-    expect_equal(AsDateTime(c("2020-03-09 16:26", NA, "2020-02-02 20:02"),
+    expect_equal(AsDateTime(c("2020-03-09 16:26", NA, "2020-02-02 20:02", ""),
                               on.parse.failure = "ignore"),
-                 structure(c(1583771160, NA, 1580673720),
+                 structure(c(1583771160, NA, 1580673720, NA),
                            class = c("POSIXct", "POSIXt"), tzone = "UTC"))
 })
 


### PR DESCRIPTION
Currently, if any value in the input vector for `AsDate` or `AsDateTime` is an empty string then all entries in the result will be `NA`. This is causing some difficulty for the LLM so we relax this to allow empty strings to be handled in the same way as NAs.