### PR TITLE
FS2-4067: Add support for days of the week and different languages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipTime
 Type: Package
 Title: Tools for Manipulating Dates and Time Series
-Version: 2.10.2
+Version: 2.10.3
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Functions to aggregate time series into strings, and convert
@@ -18,5 +18,5 @@ Remotes:
     Displayr/plotly
 Suggests:
     testthat
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Encoding: UTF-8

--- a/R/asdate.R
+++ b/R/asdate.R
@@ -58,10 +58,10 @@ AsDate <- function(x,
     parsed <- asDate(x, us.format, locale, exact)
 
     ## DS-2193 check if date has a time stamp
-    if (any(is.na(parsed)))
+    if (anyNA(parsed))
         parsed <- asDateTime(x, us.format = us.format, locale = locale, exact = exact)
 
-    if (any(is.na(parsed)))
+    if (anyNA(parsed))
     {
         result <- handleParseFailure(deparse(substitute(x)), length(na.ind), on.parse.failure)
         names(result) <- x.names
@@ -91,7 +91,7 @@ asDate <- function(x, us.format = NULL, locale = Sys.getlocale("LC_TIME"), exact
         ## First check for period dates of form
         ## Jan-Mar 2015 and 30/10/1999-27/11/2000
         pd <- parsePeriodDate(x, us.format)
-        if (!any(is.na(pd)))
+        if (!anyNA(pd))
             return(as.Date(pd))
 
         # Try out date formats with weekdays and month names first
@@ -104,7 +104,7 @@ asDate <- function(x, us.format = NULL, locale = Sys.getlocale("LC_TIME"), exact
             if (is.na(parse_date_time(x1, ord, locale = locale, quiet = TRUE)))
                 next
             parsed <- parse_date_time(x, ord, locale = locale, quiet = TRUE)
-            if (!any(is.na(parsed)))
+            if (!anyNA(parsed))
                 return(parsed)
         }
 
@@ -116,11 +116,11 @@ asDate <- function(x, us.format = NULL, locale = Sys.getlocale("LC_TIME"), exact
         ## lubridate <= 1.6.0 fails to parse bY and by orders
         ## and returns many false positives for my and ym
         parsed <- checkMonthYearFormats(x)
-        if (!any(is.na(parsed)))
+        if (!anyNA(parsed))
             return(parsed)
 
         parsed <- fast_strptime(x, "%Y")
-        if (!any(is.na(parsed)))
+        if (!anyNA(parsed))
             return(parsed)
 
     }
@@ -134,7 +134,7 @@ asDate <- function(x, us.format = NULL, locale = Sys.getlocale("LC_TIME"), exact
 #' @noRd
 isNotAllNonEmptyText <- function(x)
 {
-    is.null(x) || any(is.na(x)) || any(grepl("^[[:space:]]*$",
+    is.null(x) || anyNA(x) || any(grepl("^[[:space:]]*$",
         x, useBytes = TRUE))
 }
 
@@ -174,20 +174,20 @@ checkMonthYearFormats <- function(
     out <- checkMonthYearFormatAndParse(x, b.month, year, "%b", "%y",
                                         sep.regex.patt)
 
-    if (any(is.na(out)))  # check yb or Yb
+    if (anyNA(out))  # check yb or Yb
         out <- checkMonthYearFormatAndParse(x, year, b.month, "%y", "%b",
                                             sep.regex.patt)
 
     sep.regex.patt <- "([/-])"
-    if (any(is.na(out))) # check my or mY
+    if (anyNA(out)) # check my or mY
         out <- checkMonthYearFormatAndParse(x, m.month, year, "%m", "%y",
                                             sep.regex.patt)
 
-    if (any(is.na(out)))   # check ym or Ym
+    if (anyNA(out))   # check ym or Ym
         out <- checkMonthYearFormatAndParse(x, year, m.month, "%y", "%m",
                                             sep.regex.patt)
 
-    if (any(is.na(out)))
+    if (anyNA(out))
         return(rep.int(NA, length(x)))
 
     out
@@ -219,7 +219,7 @@ checkFormatsWithDay <- function(
     }
 
     out <- checkFormat(x, patt, ord, us.format, exact)
-    if (!any(is.na(out)))
+    if (!anyNA(out))
         return(out)
 
     ## if us.format not specified, need to check dmy
@@ -227,23 +227,22 @@ checkFormatsWithDay <- function(
     {
         patt <- dayMonthYearRegexPatt(sep.regex.patt, FALSE)
         out <- checkFormat(x, patt, "dmy", us.format, exact)
-        if (!any(is.na(out)))
+        if (!anyNA(out))
             return(out)
     }
 
     ## check formats with year first
     patt <- yearMonthDayRegexPatt(sep.regex.patt, FALSE)
     out <- checkFormat(x, patt, "ymd", us.format, exact)
-    if (!any(is.na(out)))
+    if (!anyNA(out))
         return(out)
 
     patt <- yearDayMonthRegexPatt(sep.regex.patt, FALSE)
     out <- checkFormat(x, patt, "ydm", us.format, exact)
+    if (!anyNA(out))
+        return(out)
 
-    if (any(is.na(out)))
-        return(rep.int(NA, length(x)))
-
-    out
+    return(rep.int(NA, length(x)))
 }
 
 

--- a/R/asdate.R
+++ b/R/asdate.R
@@ -7,7 +7,8 @@
 #' detected, they will be parsed using \code{AsDateTime}.
 #' @param us.format logical; whether to use the US convention for dates; can be \code{NULL}
 #' in which case both U.S. formats and international formats will be checked
-#' @param locale See \link{locales}.
+#' @param locale Controls the language used. But use "fr_FR.utf8" instead of "French" to avoid
+#'  errors with non-ascii characters. See \link{locales} for more info.
 #' @param exact see \code{\link[lubridate]{parse_date_time2}}
 #' @param on.parse.failure Character string specifying how parse failures should be handled;
 #' \code{"error"}, the default, results in an error being thrown with
@@ -108,7 +109,7 @@ asDate <- function(x, us.format = NULL, locale = Sys.getlocale("LC_TIME"), exact
         }
 
         parsed <- checkFormatsWithDay(x, us.format, exact)
-        if (!any(is.na(parsed)))
+        if (!anyNA(parsed))
             return(parsed)
 
         ## Try formats with month and year, but no day

--- a/R/asdate.R
+++ b/R/asdate.R
@@ -103,26 +103,27 @@ asDate <- function(x, us.format = NULL, locale = Sys.getlocale("LC_TIME"), exact
             if (is.na(parse_date_time(x1, ord, locale = locale, quiet = TRUE)))
                 next
             parsed <- parse_date_time(x, ord, locale = locale, quiet = TRUE)
-            if (all(!is.na(parsed)))
+            if (!any(is.na(parsed)))
                 return(parsed)
         }
 
         parsed <- checkFormatsWithDay(x, us.format, exact)
+        if (!any(is.na(parsed)))
+            return(parsed)
 
         ## Try formats with month and year, but no day
         ## lubridate <= 1.6.0 fails to parse bY and by orders
         ## and returns many false positives for my and ym
-        if (any(is.na(parsed)))
-            parsed <- checkMonthYearFormats(x)
+        parsed <- checkMonthYearFormats(x)
+        if (!any(is.na(parsed)))
+            return(parsed)
 
-        if (any(is.na(parsed)))
-            parsed <- fast_strptime(x, "%Y")
-            #parsed <- parse_date_time2(x, "Y", exact = TRUE)
+        parsed <- fast_strptime(x, "%Y")
+        if (!any(is.na(parsed)))
+            return(parsed)
 
-    }else
-        parsed <- NA
-
-    return(parsed)
+    }
+    return(NA)
 }
 
 #' Check if a supplied vector contains non-empty text in every element

--- a/R/asdatetime.R
+++ b/R/asdatetime.R
@@ -19,7 +19,7 @@ IsDateTime <- function(x, locale = Sys.getlocale("LC_TIME"))
     res <- try(suppressWarnings(AsDateTime(x, locale = locale, on.parse.failure = "silent")), silent = TRUE)
     if (inherits(res, "try-error"))
         return(FALSE)
-    return(!any(is.na(res)))
+    return(!anyNA(res))
 }
 
 
@@ -74,11 +74,11 @@ AsDateTime <- function(x,
     ## try to parse as dates with no times
     ## need to explicitly add time.zone as attr b/c
     ## as.POSIXct ignores it when it's not required for conversion
-    if (any(is.na(parsed)))
+    if (anyNA(parsed))
         parsed <- structure(as.POSIXct(asDate(x, us.format = us.format, exact = exact)),
                             tzone = time.zone)
 
-    if (any(is.na(parsed)))
+    if (anyNA(parsed))
     {
         result <- handleParseFailure(deparse(substitute(x)), length(na.ind), on.parse.failure)
         names(result) <- x.names
@@ -125,7 +125,7 @@ asDateTime <- function(x, us.format = NULL,
             if (is.na(parse_date_time(x1, ord, tz = time.zone, locale = locale, quiet = TRUE)))
                 next
             parsed <- parse_date_time(x, ord, tz = time.zone, locale = locale, quiet = TRUE)
-            if (!any(is.na(parsed)))
+            if (!anyNA(parsed))
                 return(parsed)
         }
 
@@ -224,7 +224,7 @@ checkUSformatAndParse <- function(x, ord, time.zone = "UTC",
         fmt <- ord
 
     out <- parse.fun(fmt)
-    if (any(is.na(out)))  # don't bother checking if haven't found a match yet
+    if (anyNA(out))  # don't bother checking if haven't found a match yet
         return(out)
 
     ## because md orders are checked first in AsDate and AsDateTime,

--- a/R/asdatetime.R
+++ b/R/asdatetime.R
@@ -125,7 +125,7 @@ asDateTime <- function(x, us.format = NULL,
             if (is.na(parse_date_time(x1, ord, tz = time.zone, locale = locale, quiet = TRUE)))
                 next
             parsed <- parse_date_time(x, ord, tz = time.zone, locale = locale, quiet = TRUE)
-            if (all(!is.na(parsed)))
+            if (!any(is.na(parsed)))
                 return(parsed)
         }
 
@@ -166,13 +166,8 @@ asDateTime <- function(x, us.format = NULL,
                     return(parsed)
             }
         }
-
-
-
-    }else
-        parsed <- NA
-
-    return(parsed)
+    }
+    return(NA)
 }
 
 #' Check if a string can be parsed to "bY" or "by" date format

--- a/R/period.R
+++ b/R/period.R
@@ -335,7 +335,7 @@ CompleteListPeriodNames <- function(x, by)
 #' default week start day is Sunday.
 #' @param long.name Logical; if \code{TRUE} the output string is more verbose:
 #' months will be their full names, quarters will be written as \code{"Quarter"},
-#' and \code{"week commencing"} will be added when code{'week"} is \code{"week"}.
+#' and \code{"week commencing"} will be added when \code{by} is \code{"week"}.
 #' @param ... Additional arguments passed to lubridate
 #' @importFrom lubridate floor_date make_difftime
 #' @importFrom flipU StopForUserError

--- a/man/AsDate.Rd
+++ b/man/AsDate.Rd
@@ -5,7 +5,13 @@
 \alias{ParseDates}
 \title{Parse Character Dates To POSIXct Objects}
 \usage{
-AsDate(x, us.format = NULL, exact = FALSE, on.parse.failure = "error")
+AsDate(
+  x,
+  us.format = NULL,
+  locale = Sys.getlocale("LC_TIME"),
+  exact = FALSE,
+  on.parse.failure = "error"
+)
 
 ParseDates(x, us.format = NULL)
 }
@@ -16,6 +22,8 @@ detected, they will be parsed using \code{AsDateTime}.}
 
 \item{us.format}{logical; whether to use the US convention for dates; can be \code{NULL}
 in which case both U.S. formats and international formats will be checked}
+
+\item{locale}{See \link{locales}.}
 
 \item{exact}{see \code{\link[lubridate]{parse_date_time2}}}
 

--- a/man/AsDate.Rd
+++ b/man/AsDate.Rd
@@ -23,7 +23,8 @@ detected, they will be parsed using \code{AsDateTime}.}
 \item{us.format}{logical; whether to use the US convention for dates; can be \code{NULL}
 in which case both U.S. formats and international formats will be checked}
 
-\item{locale}{See \link{locales}.}
+\item{locale}{Controls the language used. But use "fr_FR.utf8" instead of "French" to avoid
+errors with non-ascii characters. See \link{locales} for more info.}
 
 \item{exact}{see \code{\link[lubridate]{parse_date_time2}}}
 

--- a/man/AsDateTime.Rd
+++ b/man/AsDateTime.Rd
@@ -32,7 +32,8 @@ in which case both U.S. formats and international formats will be checked}
 
 \item{time.zone}{An optional time zone (default \code{"UTC"}).}
 
-\item{locale}{See \link{locales}.}
+\item{locale}{Controls the language used. But use "fr_FR.utf8" instead of "French" to avoid
+errors with non-ascii characters. See \link{locales} for more info.}
 
 \item{exact}{see \code{\link[lubridate]{parse_date_time2}}}
 

--- a/man/AsDateTime.Rd
+++ b/man/AsDateTime.Rd
@@ -5,12 +5,18 @@
 \alias{AsDateTime}
 \title{Parse Character Date-Times to POSIXct Objects}
 \usage{
-ParseDateTime(x, us.format = TRUE, time.zone = "UTC")
+ParseDateTime(
+  x,
+  us.format = TRUE,
+  time.zone = "UTC",
+  locale = Sys.getlocale("LC_TIME")
+)
 
 AsDateTime(
   x,
   us.format = NULL,
   time.zone = "UTC",
+  locale = Sys.getlocale("LC_TIME"),
   exact = FALSE,
   on.parse.failure = "error"
 )
@@ -25,6 +31,8 @@ using \code{as.POSIXct}.}
 in which case both U.S. formats and international formats will be checked}
 
 \item{time.zone}{An optional time zone (default \code{"UTC"}).}
+
+\item{locale}{See \link{locales}.}
 
 \item{exact}{see \code{\link[lubridate]{parse_date_time2}}}
 

--- a/man/IsDateTime.Rd
+++ b/man/IsDateTime.Rd
@@ -4,10 +4,12 @@
 \alias{IsDateTime}
 \title{Check whether text can be parsed as date/time}
 \usage{
-IsDateTime(x)
+IsDateTime(x, locale = Sys.getlocale("LC_TIME"))
 }
 \arguments{
 \item{x}{Vector of input text}
+
+\item{locale}{See \link{locales}.}
 }
 \description{
 Returns bool indicating whether text can be parsed as a date-time

--- a/man/Period.Rd
+++ b/man/Period.Rd
@@ -33,7 +33,7 @@ default week start day is Sunday.}
 
 \item{long.name}{Logical; if \code{TRUE} the output string is more verbose:
 months will be their full names, quarters will be written as \code{"Quarter"},
-and \code{"week commencing"} will be added when code{'week"} is \code{"week"}.}
+and \code{"week commencing"} will be added when \code{by} is \code{"week"}.}
 
 \item{...}{Additional arguments passed to lubridate}
 }

--- a/tests/testthat/test-asdate.R
+++ b/tests/testthat/test-asdate.R
@@ -36,12 +36,12 @@ test_that("AsDate", {
     expect_equal(AsDate("2. Januar 2016", locale = "de_DE.UTF-8"), dt1)
     expect_equal(AsDate("2016年1月2日"), dt1)
     expect_equal(AsDate("2016年1月2日"), dt2)
-    expect_equal(AsDate("2 Janvier 2016", locale = "fr_CA.utf8"), dt1)
-    expect_equal(AsDate("Le samedi 2 janvier 2016", locale = "fr_CA.utf8"), dt1)
+    expect_equal(AsDate("2 Janvier 2016", locale = "fr_FR.utf8"), dt1)
+    expect_equal(AsDate("Le samedi 2 janvier 2016", locale = "fr_FR.utf8"), dt1)
 
     # other languages including day of the week need the locale to be set
-    expect_equal(AsDate("samedi 2 janvier 2016", locale = "fr_CA.utf8"), dt1)
-    expect_equal(AsDate("Samstag, 2. Januar 2016", locale = "de_DE.UTF-8"), dt1)
+    expect_equal(AsDate("samedi 2 janvier 2016", locale = "fr_FR.utf8"), dt1)
+    expect_equal(AsDate("Samstag, 2. Januar 2016", locale = "de_DE.utf8"), dt1)
 
     # Numeric year month date
     expect_equal(AsDate("2010-02-03"), dt6)

--- a/tests/testthat/test-asdate.R
+++ b/tests/testthat/test-asdate.R
@@ -25,6 +25,24 @@ test_that("AsDate", {
     expect_equal(AsDate("Jun qtr 2009"), dt8)
     expect_equal(AsDate("10 Feb", us.format = "No date formatting"), NA)
 
+    # Including day of week
+    expect_equal(AsDate("Wed Feb 3, 2010"), dt6)
+    expect_equal(AsDate("Wednesday, February 3, 2010"), dt6)
+    expect_equal(AsDate("Wednesday, 3rd February, 2010"), dt6)
+    expect_equal(AsDate("2010-02-03 (Wednesday"), dt6)
+    expect_equal(AsDate("Wed, Feb 3, 2010"), dt6)
+
+    # other languages
+    expect_equal(AsDate("2. Januar 2016", locale = "de_DE.UTF-8"), dt1)
+    expect_equal(AsDate("2016年1月2日"), dt1)
+    expect_equal(AsDate("2016年1月2日"), dt2)
+    expect_equal(AsDate("2 Janvier 2016", locale = "fr_CA.utf8"), dt1)
+    expect_equal(AsDate("Le samedi 2 janvier 2016", locale = "fr_CA.utf8"), dt1)
+
+    # other languages including day of the week need the locale to be set
+    expect_equal(AsDate("samedi 2 janvier 2016", locale = "fr_CA.utf8"), dt1)
+    expect_equal(AsDate("Samstag, 2. Januar 2016", locale = "de_DE.UTF-8"), dt1)
+
     # Numeric year month date
     expect_equal(AsDate("2010-02-03"), dt6)
 

--- a/tests/testthat/test-asdatetime.R
+++ b/tests/testthat/test-asdatetime.R
@@ -138,8 +138,8 @@ test_that("AsDateTime",
     expect_equal(AsDateTime("Saturday January 02 2016 12:34AM"), dt2)
 
     # other languages including day of the week need the locale to be set
-    expect_equal(AsDateTime("samedi 2 janvier 2016 00:34:56", locale = "fr_CA.utf8"), dt1)
-    expect_equal(AsDateTime("Samstag, 2. Januar 2016 00:34:56", locale = "de_DE.UTF-8"), dt1)
+    expect_equal(AsDateTime("samedi 2 janvier 2016 00:34:56", locale = "fr_FR.utf8"), dt1)
+    expect_equal(AsDateTime("Samstag, 2. Januar 2016 00:34:56", locale = "de_DE.utf8"), dt1)
 })
 
 test_that("AsDateTime: additional support for two-digit years",

--- a/tests/testthat/test-asdatetime.R
+++ b/tests/testthat/test-asdatetime.R
@@ -109,6 +109,37 @@ test_that("AsDateTime",
     ## this example confuses lubridate very badily if ym format tried
     ## lubridate::parse_date_time2("jan-214", "ym", exact = TRUE)
     ## expect_equal(AsDateTime("jan-214"), NA)
+
+    # including timezones
+    expect_equal(AsDateTime("2016-01-02 00:34:56"), dt1)
+    expect_equal(AsDateTime("2016-01-02 00:34:56 AM"), dt1)
+    expect_equal(AsDateTime("2016-01-02 00:34:56 GMT"), dt1)
+    expect_equal(AsDateTime("2016-01-02 00:34:56 AEST"), dt1)
+    expect_equal(AsDateTime("2016-01-02T00:34:56Z"), dt1)
+
+    # including time offset
+    expect_equal(AsDateTime("2016-01-02 10:34:56 GMT+1000"), dt1)
+    expect_equal(AsDateTime("2016-01-02T10:34:56+10:00"), dt1)
+    AsDateTime("Jan 02 2016 10:34:56 GMT+1000")
+
+    # other languages
+    expect_equal(AsDateTime("2. Januar 2016 00:34:56"), dt1)
+    expect_equal(AsDateTime("2016年1月2日 00:34:56"), dt1)
+    expect_equal(AsDateTime("2016年1月2日 12:34AM"), dt2)
+    expect_equal(AsDateTime("2 Janvier 2016 00:34:56"), dt1)
+    expect_equal(AsDateTime("Le samedi 2 janvier 2016 00:34:56"), dt1)
+
+    # 2-digit month can be mis-parsed if we try 2-digit years first
+    expect_equal(AsDateTime("2004年10月6日 10:34AM"), AsDateTime("2004-10-06 10:34"))
+
+    # including day of week
+    expect_equal(AsDateTime("Sat Jan 02 2016 00:34:56"), dt1)
+    expect_equal(AsDateTime("Saturday January 02 2016 00:34:56"), dt1)
+    expect_equal(AsDateTime("Saturday January 02 2016 12:34AM"), dt2)
+
+    # other languages including day of the week need the locale to be set
+    expect_equal(AsDateTime("samedi 2 janvier 2016 00:34:56", locale = "fr_CA.utf8"), dt1)
+    expect_equal(AsDateTime("Samstag, 2. Januar 2016 00:34:56", locale = "de_DE.UTF-8"), dt1)
 })
 
 test_that("AsDateTime: additional support for two-digit years",


### PR DESCRIPTION
This PR adds support for AsDate and AsDateTime to parse date strings that contain days of the week. Although the day itself is not used to identify the date, we didn't strip it out because when date strings contain both the day of the week and a named month there is no clear way to distinguish which part of the string it is.

We have focused on using lubridate so that the date parsing can work with multiple languages (we tried common formats for chinese, french and german as those are the languages available in the Displayr company settings). This involves exposing the parameter for `locale` so it can be specified for `lubridate::parse_date_time`. 